### PR TITLE
Add support to load custom LDIF schema.

### DIFF
--- a/src/main/java/com/btmatthews/ldapunit/DirectoryServerConfiguration.java
+++ b/src/main/java/com/btmatthews/ldapunit/DirectoryServerConfiguration.java
@@ -78,4 +78,14 @@ public @interface DirectoryServerConfiguration {
      * @return An array of LDIF file paths.
      */
     String[] ldifFiles() default {};
+    
+    /**
+     * The location of the optional schema LDIF file that can be use to have a LDAP directory with a custom schema.
+     * The file may located on the file system or the classpath. The classpath is checked first and then falls back
+     * to the file system if it was no found on the class path.
+     * 
+     * @return The file path of the schema in LDIF.
+     */
+    String ldifSchema() default "";
+    
 }

--- a/src/main/java/com/btmatthews/ldapunit/DirectoryServerStatement.java
+++ b/src/main/java/com/btmatthews/ldapunit/DirectoryServerStatement.java
@@ -62,10 +62,10 @@ final class DirectoryServerStatement extends Statement {
         final InMemoryDirectoryServer server;
         if (annotation.ldifFiles().length == 0) {
             server = DirectoryServerUtils.startServer(annotation.port(), annotation.baseDN(),
-                    annotation.authDN(), annotation.authPassword(), annotation.ldifFile());
+                    annotation.authDN(), annotation.authPassword(), annotation.ldifFile(), annotation.ldifSchema());
         } else {
             server = DirectoryServerUtils.startServer(annotation.port(), annotation.baseDN(),
-                    annotation.authDN(), annotation.authPassword(), annotation.ldifFiles());
+                    annotation.authDN(), annotation.authPassword(), annotation.ldifFiles(), annotation.ldifSchema());
         }
         try {
             base.evaluate();

--- a/src/main/java/com/btmatthews/ldapunit/DirectoryServerUtils.java
+++ b/src/main/java/com/btmatthews/ldapunit/DirectoryServerUtils.java
@@ -16,18 +16,26 @@
 
 package com.btmatthews.ldapunit;
 
-import com.unboundid.ldap.listener.InMemoryDirectoryServer;
-import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
-import com.unboundid.ldap.listener.InMemoryListenerConfig;
-import com.unboundid.ldap.sdk.*;
-import com.unboundid.ldif.LDIFChangeRecord;
-import com.unboundid.ldif.LDIFException;
-import com.unboundid.ldif.LDIFReader;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.DN;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.schema.Schema;
+import com.unboundid.ldif.LDIFChangeRecord;
+import com.unboundid.ldif.LDIFException;
+import com.unboundid.ldif.LDIFReader;
 
 /**
  * Helper functions to start the in-memory LDAP directory server, load LDAP directory entries from an LDIF files and
@@ -52,9 +60,10 @@ final class DirectoryServerUtils {
                                                final String baseDN,
                                                final String authDN,
                                                final String authPassword,
-                                               final String ldifFile)
+                                               final String ldifFile,
+                                               final String ldifSchema)
             throws LDIFException, LDAPException, IOException {
-        return startServer(port, baseDN, authDN, authPassword, new String[]{ldifFile});
+        return startServer(port, baseDN, authDN, authPassword, new String[]{ldifFile}, ldifSchema);
     }
 
     /**
@@ -70,10 +79,12 @@ final class DirectoryServerUtils {
                                                final String baseDN,
                                                final String authDN,
                                                final String authPassword,
-                                               final String[] ldifFiles)
+                                               final String[] ldifFiles,
+                                               final String ldifSchema)
             throws LDIFException, LDAPException, IOException {
         final InMemoryListenerConfig listenerConfig = InMemoryListenerConfig.createLDAPConfig("default", port);
         final InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(new DN(baseDN));
+        loadSchema(config, ldifSchema);
         config.setListenerConfigs(listenerConfig);
         config.addAdditionalBindCredentials(authDN, authPassword);
         final InMemoryDirectoryServer server = new InMemoryDirectoryServer(config);
@@ -122,9 +133,55 @@ final class DirectoryServerUtils {
                 changeRecord.processChange(connection);
                 changeRecord = reader.readChangeRecord(true);
             }
+            reader.close();
         } finally {
             inputStream.close();
         }
+    }
+    
+    /**
+     * Load schema from a file to set in the LDAP directory.
+     * 
+     * @param config The configuration of the memory directory server.
+     * @param ldifSchema The LDIF schema resource name or file path.
+     * @throws LDIFException	If there was an error in the LDIF schema.	
+     * @throws IOException		If there was a problem reading the LDIF schema from the file.
+     */
+    private static void loadSchema(final InMemoryDirectoryServerConfig config,
+    							  final String ldifSchema)
+    	    throws LDIFException, IOException {
+		if ( ldifSchema != null && !ldifSchema.isEmpty() ) {
+			Schema schema = null;
+			final File file = new File(ldifSchema);
+			final String path = getPathFromResourceName(ldifSchema);
+			
+			if (path != null) {
+				schema = Schema.getSchema(path);
+			}
+			else if (file.exists()) {
+				schema = Schema.getSchema(file);
+			}
+			
+			if (schema != null) {
+				config.setSchema(schema);
+			}
+		}
+	}
+    
+    /**
+     * @param name The resource name.
+     * @return The filesystem path of the resource file, null if not exists.
+     */
+    private static String getPathFromResourceName(String name) {
+    	try {
+			URL url = ClassLoader.getSystemResource(name);
+			if ( url != null ) {
+				return Paths.get( url.toURI() ).toString();
+			}
+		} catch (URISyntaxException e) {
+			// Nothing
+		}
+    	return null;
     }
 
     /**

--- a/src/test/java/com/btmatthews/ldapunit/TestDirectoryTesterConnection.java
+++ b/src/test/java/com/btmatthews/ldapunit/TestDirectoryTesterConnection.java
@@ -74,7 +74,7 @@ public class TestDirectoryTesterConnection {
             @Override
             public void run() {
                 try {
-                    server = DirectoryServerUtils.startServer(LDAP_PORT, ROOT_DN, AUTH_DN, AUTH_PASSWORD, new String[0]);
+                    server = DirectoryServerUtils.startServer(LDAP_PORT, ROOT_DN, AUTH_DN, AUTH_PASSWORD, new String[0], "");
                 } catch (final Exception e) {
                 }
             }


### PR DESCRIPTION
Simply added the option to load a custom schema into LDAP directory.

Basically I added ldifSchema in the annotation DirectoryServerConfiguration class and use the method setSchema() in the server's configuration.
